### PR TITLE
Adding HEVC for Series H to TranscodeParams case statement

### DIFF
--- a/MediaBrowser 3/app/javascript/Gui/GuiPlayer/GuiPlayer_TranscodeParams.js
+++ b/MediaBrowser 3/app/javascript/Gui/GuiPlayer/GuiPlayer_TranscodeParams.js
@@ -45,6 +45,15 @@ GuiPlayer_TranscodeParams.getParameters = function(codec) {
     			this.level = 51;
     			this.profile = ["Base","Constrained Baseline","Baseline","Main","High"];
     			break;
+    	    case "hevc":    	    
+    	    	this.codec = true;
+    	    	this.container = ["asf","avi","mkv","mp4","3gpp","mpg","mpeg","ts","m4v","m2ts","mov","vro","tp","trp","flv","vob","svi","mts","divx"];
+    	    	this.resolution = [1920,1080];
+    	    	this.bitrate = 50720000;
+    	    	this.framerate = 30;
+    	    	this.level = 120;			//  Level 4  (HEVC is x30 not x10 like h264)
+    	    	this.profile = ["Base","Constrained Baseline","Baseline","Main","High"];
+		break;			
     	    case "h265":
     	    	this.codec = true;
     	    	this.container = ["asf","avi","mkv","mp4","3gpp","mpg","mpeg","ts","m4v","m2ts","mov","vro","tp","trp","flv","vob","svi","mts","divx"];


### PR DESCRIPTION
Enables Series H TVs to direct play some HEVC files.  Tested successfully on H6350 TV.
